### PR TITLE
Add required Node version to readme / package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Commands for working with lnd balances.
 
 ## Install 
 
+Requires Node v10.4.0+
+
 ```shell
 npm install -g balanceofsatoshis
 ```

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "devDependencies": {
     "tap": "14.6.1"
   },
+  "engines": {
+    "node": ">=10.4.0"
+  },
   "keywords": [
     "cli",
     "lightning",


### PR DESCRIPTION
Since this project uses bigint, it requires node 10.4.0+ to run. Thought it'd be helpful to note instead of someone trying to figure out from the cryptic error message you'd get.

A further improvement could be to check for bigint support before allowing installation / running of the command.