### PR TITLE
Clarifying default parameters in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ bos utxos
 
 ## Saved Nodes Directory
 
-By default `bos` tries to locate `tls.cert` and `admin.macaroon` in the default
-`lnd` location on the local machine (`~/.lnd/` on Linux, and
-`~/Library/Application Support/Lnd/` on MacOS). 
+By default `bos` expects `tls.cert` in the root of the default `lnd` directory and `admin.macaroon` in `<default_lnd_dir>/data/chain/bitcoin/<network>`.
+
+Default lnd directories:
+* macOS: `~/Library/Application Support/Lnd/`
+* Linux: `~/.lnd/`
 
 It will check first for a mainnet macaroon, then a testnet macaroon.
 


### PR DESCRIPTION
This PR makes a simple text change in README.md that clarifies the expected file structure of the default lnd folder.