### PR TITLE
Fix default LND datadir path on Windows

### DIFF
--- a/lnd/lnd_directory.js
+++ b/lnd/lnd_directory.js
@@ -37,7 +37,7 @@ module.exports = ({os}) => {
     return {path: join(os.homedir(), 'Library', 'Application Support', 'Lnd')};
 
   case platforms.windows:
-    return {path: join(os.homedir(), 'Lnd')};
+    return {path: join(os.homedir(), 'AppData', 'Local', 'Lnd')};
 
   default:
     return {path: join(os.homedir(), '.lnd')};


### PR DESCRIPTION
Reflects current LND default of `%localappdata%/Lnd`

https://github.com/lightningnetwork/lnd/blob/1c398d5f265c3c4ff0da8898d69bda4bd9197a0e/sample-lnd.conf#L8