### PR TITLE
Added small CLI tip for open command

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,25 @@ You can also add a JSON file to your .bos directory: config.json, add
 
 Some commands are designed to return outputs that can be piped or used in other CLI programs.
 
+### Open many channels
+
+Make a textfile in the terminal with newline separated pubkeys and the capacity of the channels.
+
+```shell
+cat bos_channels.txt
+
+       │ File: bos_channels.txt
+───────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   1   │ 0337...1986 --amount=3000000
+   2   │ 02a4...20de --amount=3000000
+   3   │ 023c...0dec --amount=1000000
+
+```
+
+```shell
+bos open $(cat bos_channels.txt)
+```
+
 ### Summarize Numbers
 
 ```shell


### PR DESCRIPTION
I think this is useful because the open command can get very messy and its easier to double check the pubkeys and amounts when in an editor rather than the CLI prompt.

Additionally this file can be used to take notes over time of potential nodes you want to open to and then when fees are low you can quickly issue the command.