### PR TITLE
Changed Dockerfile base from node:latest to node:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest AS build
+FROM node:alpine
 
 # UID / GID 1000 is default for user `node` in the `node:latest` image, this
 # way the process will run as a non-root user


### PR DESCRIPTION
This cuts docker image size down to a quarter of the original container size (~380MB -> ~80MB)

| Before |
| ------- |
| ![Screenshot 2021-11-29 223748](https://user-images.githubusercontent.com/433270/143998143-8b787a76-50e6-4e96-a516-12998a12c2ef.jpg) |
| After |
| ![Screenshot 2021-11-29 223805](https://user-images.githubusercontent.com/433270/143998202-71cde73a-dfeb-4f6e-ac9b-88eee80d538e.jpg) |

