### PR TITLE
support to use proxy to communicate with telegram

### DIFF
--- a/bos
+++ b/bos
@@ -1605,11 +1605,13 @@ prog
   .help('Supported updates: forwards, received payments, etc')
   .help('Multiple nodes are supported by repeating the `--node` flag')
   .help('See README for info on persisting the bot through Docker/nohup')
+  .help('To use proxy connection, create JSON file and pass its path to `--use-proxy`')
+  .help('JSON file can contain keys such as {host, port, userId, password}')
   .option('--budget <amount>', 'Spending amount to allow', INT, Number())
   .option('--connect <connect_code>', 'Connection code', INT)
   .option('--ignore-forwards-below <amount>', 'Ignore forwards of value', INT)
   .option('--node <node_name>', 'Node to connect to Telegram', REPEATABLE)
-  .option('--use-proxy', 'Proxy agent to connect to Telegram')
+  .option('--use-proxy <path>', 'Proxy agent to connect to Telegram')
   .option('--reset-api-key', 'Reset the Telegram API key')
   .action((args, options, logger) => {
     return new Promise(async (resolve, reject) => {

--- a/bos
+++ b/bos
@@ -1609,6 +1609,7 @@ prog
   .option('--connect <connect_code>', 'Connection code', INT)
   .option('--ignore-forwards-below <amount>', 'Ignore forwards of value', INT)
   .option('--node <node_name>', 'Node to connect to Telegram', REPEATABLE)
+  .option('--use-proxy', 'Proxy agent to connect to Telegram')
   .option('--reset-api-key', 'Reset the Telegram API key')
   .action((args, options, logger) => {
     return new Promise(async (resolve, reject) => {
@@ -1627,6 +1628,7 @@ prog
           nodes: flatten([options.node].filter(n => !!n)),
           payments: {limit: options.budget},
           request: commands.fetchRequest({fetch}),
+          use_proxy: options.useProxy || undefined,
         });
       } catch (err) {
         return reject(logger.error({err}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "psbt": "1.1.10",
         "qrcode-terminal": "0.12.0",
         "sanitize-filename": "1.6.3",
+        "socks-proxy-agent": "^6.1.1",
         "table": "6.8.0",
         "update-notifier": "5.1.0",
         "window-size": "1.1.1"
@@ -2879,6 +2880,38 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -5613,6 +5646,11 @@
       "engines": {
         "node": ">=10.4.0"
       }
+    },
+    "node_modules/ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -8991,6 +9029,62 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -12236,6 +12330,29 @@
         "negotiator": "0.6.2"
       }
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -14390,6 +14507,11 @@
         "bolt09": "0.2.1",
         "secp256k1": "4.0.3"
       }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -17008,6 +17130,45 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "psbt": "1.1.10",
         "qrcode-terminal": "0.12.0",
         "sanitize-filename": "1.6.3",
-        "socks-proxy-agent": "^6.1.1",
+        "socks-proxy-agent": "6.1.1",
         "table": "6.8.0",
         "update-notifier": "5.1.0",
         "window-size": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "psbt": "1.1.10",
     "qrcode-terminal": "0.12.0",
     "sanitize-filename": "1.6.3",
-    "socks-proxy-agent": "^6.1.1",
+    "socks-proxy-agent": "6.1.1",
     "table": "6.8.0",
     "update-notifier": "5.1.0",
     "window-size": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "psbt": "1.1.10",
     "qrcode-terminal": "0.12.0",
     "sanitize-filename": "1.6.3",
+    "socks-proxy-agent": "^6.1.1",
     "table": "6.8.0",
     "update-notifier": "5.1.0",
     "window-size": "1.1.1"

--- a/telegram/connect_to_telegram.js
+++ b/telegram/connect_to_telegram.js
@@ -114,6 +114,7 @@ module.exports = (args, cbk) => {
               },
               logger: args.logger,
               payments: {limit},
+              proxy: args.use_proxy,
               request: args.request,
             },
             err => {

--- a/telegram/connect_to_telegram.js
+++ b/telegram/connect_to_telegram.js
@@ -114,7 +114,7 @@ module.exports = (args, cbk) => {
               },
               logger: args.logger,
               payments: {limit},
-              proxy: args.use_proxy,
+              proxy_path: args.use_proxy,
               request: args.request,
             },
             err => {


### PR DESCRIPTION
Added new package:
[socks-proxy-agent](https://github.com/TooTallNate/node-socks-proxy-agent)

Grammy documentation on proxy support: [Grammy Docs](https://grammy.dev/advanced/proxy.html)

Create a file called `proxy_agent.json` in the `.bos` dir

Tor example:
```
{
  "host": "127.0.0.1",
  "port": 9050
}
```

Used this docker image for testing: [Tor Docker](https://hub.docker.com/r/palnabarun/tor)


Edited files:

- bos
- telegram/start_telegram_bot.js
- telegram/connect_to_telegram.js