### PR TITLE
filter by disk usage for peers command

### DIFF
--- a/bos
+++ b/bos
@@ -1147,7 +1147,7 @@ prog
   .help('Icons: 🧊 delayed coop close, ⏳ pending channel, 🚫 in disabled')
   .help('Icons: 🦐 limited max htlc')
   .help('Filters can take formula expressions like inbound_liquidity > 1*m')
-  .help('Filter formula variables: AGE|INBOUND_LIQUIDITY|OUTBOUND_LIQUIDITY')
+  .help('Filter formula variables: AGE|DISK_USAGE_MB|INBOUND_LIQUIDITY|OUTBOUND_LIQUIDITY')
   .option('--active', 'Only active peer channels')
   .option('--complete', 'Show complete set of records in non table view')
   .option('--fee-days <past_days>', 'Include fees earned over n days', INT)

--- a/network/get_peers.js
+++ b/network/get_peers.js
@@ -487,10 +487,11 @@ module.exports = (args, cbk) => {
             .filter(n => n !== undefined);
 
           const disabled = policies.map(n => !!n.is_disabled).filter(n => !!n);
-          const pastStates = sumOf(active.map(n => n.past_states));
-
+          
           const feeRate = !feeRates.length ? undefined : max(...feeRates);
           const maxHtlcSizes = policies.map(n => n.max_htlc_mtokens);
+          const pastStates = sumOf(active.map(n => n.past_states));
+          
           const totalCapacity = sumOf(active.map(n => n.capacity));
 
           const totalMaxHtlc = mtokensAsTokens(sumOfBig(maxHtlcSizes));

--- a/network/get_peers.js
+++ b/network/get_peers.js
@@ -30,6 +30,7 @@ const {sortBy} = require('./../arrays');
 const closedSorts = ['fee_earnings', 'first_connected'];
 const defaultInvoicesLimit = 200;
 const defaultSort = 'first_connected';
+const estimateDiskFootprint = n => `${(n*500/1e6).toFixed(2)}`;
 const fromNow = epoch => !epoch ? undefined : moment(epoch * 1e3).fromNow();
 const {isArray} = Array;
 const {max} = Math;
@@ -486,6 +487,8 @@ module.exports = (args, cbk) => {
             .filter(n => n !== undefined);
 
           const disabled = policies.map(n => !!n.is_disabled).filter(n => !!n);
+          const pastStates = sumOf(active.map(n => n.past_states));
+
           const feeRate = !feeRates.length ? undefined : max(...feeRates);
           const maxHtlcSizes = policies.map(n => n.max_htlc_mtokens);
           const totalCapacity = sumOf(active.map(n => n.capacity));
@@ -503,6 +506,7 @@ module.exports = (args, cbk) => {
             filters: args.filters || [],
             variables: {
               age: blocks,
+              disk_usage_mb: estimateDiskFootprint(pastStates),
               fee_earnings: mtokensAsTokens(feeMtokens),
               inbound_fee_rate: feeRate,
               inbound_liquidity: sumOf(channels.map(n => n.remote_balance)),


### PR DESCRIPTION
Added a filter variable called `disk_usage_mb` to `peers` command to filter peers by disk usage.

Files changed:
bos
network/get_peers.js