### PR TITLE
[peers]: depracate flags and add capacity filter

### DIFF
--- a/bos
+++ b/bos
@@ -1222,6 +1222,7 @@ prog
   .help('Icons: 🦐 limited max htlc')
   .help('Filters can take formula expressions to limit results')
   .help('Filter variable AGE: "age > 144 * 7" for peers older than a week')
+  .help('Filter variable CAPACITY: "capacity > 8*m"')
   .help('Filter variable DISK_USAGE_MB: "disk_usage_mb > 9" for disk estimate')
   .help('Filter variable INBOUND_LIQUIDITY: "inbound_liquidity > 1*m"')
   .help('Filter variable OUTBOUND_LIQUIDITY: "outbound_liquidity > 1*m"')
@@ -1230,12 +1231,10 @@ prog
   .option('--fee-days <past_days>', 'Include fees earned over n days', INT)
   .option('--filter <formula>', 'Filter formula to apply', REPEATABLE)
   .option('--idle-days <days>', 'No receives or routes for n days', INT)
-  .option('--inbound-below <amount>', 'Inbound liquidity below amount', INT)
   .option('--no-color', 'Mute all colors')
   .option('--node <node_name>', 'Node to get peers for')
   .option('--offline', 'Only offline peer channels')
   .option('--omit <key>', 'Omit peer with public key', REPEATABLE)
-  .option('--outbound-below <amount>', 'Outbound liquidity below amount', INT)
   .option('--private', 'Only private channels')
   .option('--public', 'Only peers with public channels')
   .option('--sort <by>', 'Sort results by peer attribute', peerSortOptions)
@@ -1250,7 +1249,6 @@ prog
           filters: flatten([options.filter].filter(n => !!n)),
           fs: {getFile: readFile},
           idle_days: options.idleDays || undefined,
-          inbound_liquidity_below: options.inboundBelow,
           is_active: !!options.active,
           is_monochrome: !!options.noColor,
           is_offline: !!options.offline,
@@ -1259,7 +1257,6 @@ prog
           is_table: !options.complete,
           lnd: (await lnd.authenticatedLnd({logger, node: options.node})).lnd,
           omit: flatten([options.omit].filter(n => !!n)),
-          outbound_liquidity_below: options.outboundBelow,
           sort_by: options.sort,
           tags: flatten([options.tag].filter(n => !!n)),
         },

--- a/network/get_peers.js
+++ b/network/get_peers.js
@@ -58,7 +58,6 @@ const maxPaySize = 4294967;
       getFile: <Read File Contents Function> (path, cbk) => {}
     }
     [idle_days]: <Not Active For Days Number>
-    [inbound_liquidity_below]: <Inbound Liquidity Below Tokens Number>
     [is_active]: <Active Channels Only Bool>
     [is_monochrome]: <Mute Colors Bool>
     [is_offline]: <Offline Channels Only Bool>
@@ -67,7 +66,6 @@ const maxPaySize = 4294967;
     [is_table]: <Peers As Table Bool>
     lnd: <Authenticated LND gRPC API Object>
     omit: [<Omit Peer With Public Key Hex String>]
-    [outbound_liquidity_below]: <Outbound Liquidity Below Tokens Number>
     [sort_by]: <Sort Results By Attribute String>
     [tags]: [<Tag Identifier String>]
   }
@@ -415,8 +413,6 @@ module.exports = (args, cbk) => {
         },
         {});
 
-        const maxInbound = args.inbound_liquidity_below;
-        const maxOutbound = args.outbound_liquidity_below;
         const {network} = getNetwork.value || {};
         const peerKeys = getChannels.channels.map(n => n.partner_public_key);
         const wallet = await getHeight({lnd: args.lnd});
@@ -507,6 +503,7 @@ module.exports = (args, cbk) => {
             filters: args.filters || [],
             variables: {
               age: blocks,
+              capacity: totalCapacity,
               disk_usage_mb: estimateDiskFootprint(pastStates),
               fee_earnings: mtokensAsTokens(feeMtokens),
               inbound_fee_rate: feeRate,
@@ -565,8 +562,6 @@ module.exports = (args, cbk) => {
         return {
           peers: sortBy({array: peers, attribute: args.sort_by || defaultSort})
             .sorted
-            .filter(n => !maxInbound || n.inbound_liquidity < maxInbound)
-            .filter(n => !maxOutbound || n.outbound_liquidity < maxOutbound)
             .filter(n => args.omit.indexOf(n.public_key) === notFoundIndex)
             .filter(n => {
               // Always return peer when no idle days are specified


### PR DESCRIPTION
Depracated the flags `inbound-below` and `outbound-below` and added `capacity` filter to filter formulas.

Files changed:
bos
network/get_peers.js