### PR TITLE
[telegram] Check access for mempool and version commands

### DIFF
--- a/telegram/start_telegram_bot.js
+++ b/telegram/start_telegram_bot.js
@@ -302,6 +302,8 @@ module.exports = (args, cbk) => {
         args.bot.command('mempool', async ctx => {
           try {
             return await handleMempoolCommand({
+              from: ctx.message.from.id,
+              id: connectedId,
               reply: n => ctx.reply(n, markdown),
               request: args.request,
             });
@@ -409,6 +411,8 @@ module.exports = (args, cbk) => {
             await handleVersionCommand({
               named,
               version,
+              from: ctx.message.from.id,
+              id: connectedId,
               request: args.request,
               reply: n => ctx.reply(n, markdown),
             });


### PR DESCRIPTION
Added access check for `/version` and `/mempool` commands.

Files changed:
telegram/start_telegram_bot.js

https://github.com/alexbosworth/balanceofsatoshis/issues/281