### PR TITLE
Add summary to graph command output

### DIFF
--- a/bos
+++ b/bos
@@ -798,7 +798,6 @@ prog
 
         return network.getGraphEntry({
           lnd,
-          logger,
           filters: flatten([options.filter].filter(n => !!n)),
           fs: {getFile: readFile},
           query: args.aliasOrPublicKey.trim(),

--- a/network/get_graph_entry.js
+++ b/network/get_graph_entry.js
@@ -49,7 +49,6 @@ const uniq = arr => Array.from(new Set(arr));
       getFile: <Read File Contents Function> (path, cbk) => {}
     }
     lnd: <Authenticated LND API Object>
-    logger: <Winston Logger Object>
     query: <Graph Query String>
     sort: <Sort By Field String>
   }

--- a/network/get_graph_entry.js
+++ b/network/get_graph_entry.js
@@ -60,7 +60,7 @@ const uniq = arr => Array.from(new Set(arr));
     rows_summary: [[<Table Cell String>]]
   }
 */
-module.exports = ({filters, fs, lnd, logger, query, sort}, cbk) => {
+module.exports = ({filters, fs, lnd, query, sort}, cbk) => {
   return new Promise((resolve, reject) => {
     return asyncAuto({
       // Check arguments
@@ -75,10 +75,6 @@ module.exports = ({filters, fs, lnd, logger, query, sort}, cbk) => {
 
         if (!lnd) {
           return cbk([400, 'ExpectedAuthenticatedLndToGetGraphEntry']);
-        }
-
-        if (!logger) {
-          return cbk([400, 'ExpectedWinstonLoggerToGetGraphEntry']);
         }
 
         if (!query) {


### PR DESCRIPTION
Graph command logs the summary today, I made it a return value which outputs as a table as it would be helpful for me to get the summary output via Rest API.

Please let me know what you think.

Files changed:
bos
network/get_graph_entry.js