### PR TITLE
[chart-payments-received]: Start and end dates for chart-payments-received

### DIFF
--- a/bos
+++ b/bos
@@ -441,13 +441,17 @@ prog
   .command('chart-payments-received', 'Get a chart of received payments')
   .help('Show chart for settled invoices from external parties')
   .option('--days <days>', 'Chart over the past number of days', INT, 60)
+  .option('--end <end_date>', 'End date for chart in YYYY-MM-DD format')
   .option('--node <node_name>', 'Get payments from saved node(s)', REPEATABLE)
+  .option('--start <start_date>', 'Start date for chart in YYYY-MM-DD format')
   .action((args, options, logger) => {
     return new Promise(async (resolve, reject) => {
       try {
         return wallets.getReceivedChart({
           days: options.days,
+          end_date: options.end,
           lnds: (await lnd.getLnds({logger, nodes: options.node})).lnds,
+          start_date: options.start,
         },
         responses.returnChart({logger, reject, resolve, data: 'data'}));
       } catch (err) {

--- a/bos
+++ b/bos
@@ -440,10 +440,10 @@ prog
   // Chart earnings from payments received
   .command('chart-payments-received', 'Get a chart of received payments')
   .help('Show chart for settled invoices from external parties')
-  .option('--days <days>', 'Chart over the past number of days', INT, 60)
-  .option('--end <end_date>', 'End date for chart in YYYY-MM-DD format')
+  .option('--days <days>', 'Chart over the past number of days', INT)
+  .option('--end <end_date>', 'End date for chart in YYYY-MM-DD format', STRING)
   .option('--node <node_name>', 'Get payments from saved node(s)', REPEATABLE)
-  .option('--start <start_date>', 'Start date for chart in YYYY-MM-DD format')
+  .option('--start <start_date>', 'Start date for chart in YYYY-MM-DD format', STRING)
   .action((args, options, logger) => {
     return new Promise(async (resolve, reject) => {
       try {

--- a/wallets/get_received_chart.js
+++ b/wallets/get_received_chart.js
@@ -11,6 +11,7 @@ const {returnResult} = require('asyncjs-util');
 const {segmentMeasure} = require('./../display');
 const {sumsForSegment} = require('./../display');
 
+const defaultDays = 60;
 const flatten = arr => [].concat(...arr);
 const {isArray} = Array;
 const isNumber = n => !isNaN(n);
@@ -40,10 +41,6 @@ module.exports = (args, cbk) => {
     return asyncAuto({
       // Check arguments
       validate: cbk => {
-        if (!args.days) {
-          return cbk([400, 'ExpectedNumberOfDaysToGetFeesOverForChart']);
-        }
-
         if (!isArray(args.lnds)) {
           return cbk([400, 'ExpectedLndToGetFeesChart']);
         }
@@ -53,6 +50,10 @@ module.exports = (args, cbk) => {
         }
 
         if (!!args.start_date || !!args.end_date) {
+          if ((!!args.end_date || !!args.start_date) && !!args.days ) {
+            return cbk([400, 'ExpectedEitherDaysOrDatesToGetFeesChart']);
+          }
+          
           if (!args.start_date || !args.end_date) {
             return cbk([400, 'ExpectedStartAndEndDateToGetFeesChart']);
           }
@@ -83,7 +84,7 @@ module.exports = (args, cbk) => {
       // Segment measure
       segment: ['validate', ({}, cbk) => {
         if (!args.start_date && !args.end_date) {
-          return cbk(null, segmentMeasure({days: args.days}));
+          return cbk(null, segmentMeasure({days: args.days || defaultDays}));
         }
 
         const days = moment(args.end_date).diff(args.start_date, 'days');
@@ -96,7 +97,7 @@ module.exports = (args, cbk) => {
           return cbk(null, moment(args.start_date));
         }
 
-        return cbk(null, moment().subtract(args.days, 'days'));
+        return cbk(null, moment().subtract(args.days || defaultDays, 'days'));
       }],
 
       // End date for received payments


### PR DESCRIPTION
Added start and end flags for chart-payments-received to get payments for a range of dates. Start and end flags take YYYY-MM-DD format.

Files changed:
bos
get_received_chart.js