### PR TITLE
Add start end flags for chart-chain-fees

### DIFF
--- a/bos
+++ b/bos
@@ -351,17 +351,21 @@ prog
   .command('chart-chain-fees', 'Get a chart of chain fee expenses')
   .help('Show chart of mining fee expenditure over time')
   .help('Privacy note: this requests tx data from third parties')
-  .option('--days <days>', 'Chart over the past number of days', INT, 60)
+  .option('--days <days>', 'Chart over the past number of days', INT)
+  .option('--end <end_date>', 'End date for chart as YYYY-MM-DD', STRING)
   .option('--no-color', 'Disable colors')
   .option('--node <node_name>', 'Chain fees from saved node(s)', REPEATABLE)
+  .option('--start <start_date>', 'Start date for chart as YYYY-MM-DD', STRING)
   .action((args, options, logger) => {
     return new Promise(async (resolve, reject) => {
       try {
         return routing.getChainFeesChart({
           days: options.days,
+          end_date: options.end,
           is_monochrome: !!options.noColor,
           lnds: (await lnd.getLnds({logger, nodes: options.node})).lnds,
           request: commands.simpleRequest,
+          start_date: options.start,
         },
         responses.returnChart({logger, reject, resolve, data: 'data'}));
       } catch (err) {

--- a/display/segment_measure.js
+++ b/display/segment_measure.js
@@ -11,6 +11,7 @@ const maxChartDays = 90;
 
   {
     days: <Days Count Number>
+    [end]: <End Date String>
     [start]: <Start Date YYYY-MM-DD String>
   }
 
@@ -20,15 +21,15 @@ const maxChartDays = 90;
     segments: <Count of Segments In Window Number>
   }
 */
-module.exports = ({days, start}) => {
+module.exports = ({days, end, start}) => {
   // A chart with a lot of days should be seen as weeks
   if (days > maxChartDays) {
     return {measure: 'week', segments: floor(days / daysPerWeek)};
   }
 
   // A chart with a near start date should be seen as hours from start
-  if (!!start && !days < minChartDays) {
-    return {measure: 'hour', segments: hoursBetween(moment(), start)};
+  if (!!start && !!end && days < minChartDays) {
+    return {measure: 'hour', segments: hoursBetween(moment(end), start)};
   }
 
   // A chart with very few days should be seen as hours

--- a/routing/fees_for_segment.js
+++ b/routing/fees_for_segment.js
@@ -6,6 +6,7 @@ const defaultSegmentBy = 'created_at';
 
   {
     [by]: <Segment By Attribute String>
+    [end]: <End Date String>
     forwards: [{
       created_at: <Created At ISO 8601 Date String>
       fee: <Fee Tokens Number>
@@ -20,9 +21,9 @@ const defaultSegmentBy = 'created_at';
     fees: [<Fee Earnings In Segment Number>]
   }
 */
-module.exports = ({by, forwards, measure, segments}) => {
+module.exports = ({by, end, forwards, measure, segments}) => {
   const fees = [...Array(segments)].map((_, i) => {
-    const segment = moment().subtract(i, measure);
+    const segment = moment(end).subtract(i, measure);
 
     const segmentForwards = forwards.filter(forward => {
       const forwardDate = moment(forward[by || defaultSegmentBy]);

--- a/routing/get_chain_fees_chart.js
+++ b/routing/get_chain_fees_chart.js
@@ -147,7 +147,7 @@ module.exports = (args, cbk) => {
 
       // Segment measure
       measure: ['validate', ({}, cbk) => {
-        const days = args.days || daysBetween(args.end_date, args.start_date);
+        const days = (!!args.days || !!args.start_date) ? (args.days || daysBetween(args.end_date, args.start_date)) : defaultDays;
 
         if (days > maxChartDays) {
           return cbk(null, 'week');
@@ -160,7 +160,7 @@ module.exports = (args, cbk) => {
 
       // Total number of segments
       segments: ['measure', ({measure}, cbk) => {
-        const days = args.days || daysBetween(args.end_date, args.start_date);
+        const days = (!!args.days || !!args.start_date) ? (args.days || daysBetween(args.end_date, args.start_date)) : defaultDays;
         
         switch (measure) {
         case 'hour':

--- a/routing/get_chain_fees_chart.js
+++ b/routing/get_chain_fees_chart.js
@@ -8,7 +8,7 @@ const {returnResult} = require('asyncjs-util');
 
 const feesForSegment = require('./fees_for_segment');
 
-const daysBetween = (a, b) => moment(a).diff(b, 'days');
+const daysBetween = (a, b) => moment(a).diff(b, 'days') || 1;
 const daysPerWeek = 7;
 const defaultDays = 60;
 const isDate = n => /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$/.test(n);

--- a/wallets/get_received_chart.js
+++ b/wallets/get_received_chart.js
@@ -118,7 +118,7 @@ module.exports = (args, cbk) => {
 
         const days = daysBetween(args.end_date, args.start_date);
 
-        return cbk(null, segmentMeasure({days, start: args.start_date}));
+        return cbk(null, segmentMeasure({days, end: args.end_date, start: args.start_date}));
       }],
 
       // Start date for received payments


### PR DESCRIPTION
Added start and end flags for chart-chain-fees command.

Fixed a bug which is causing wrong duration calculation for chart-payments-received.

Over here if you specify a start and end flags, it always calculates difference between today and start date.
Example: `Received in 729 hours from 07/12/2022 to 07/13/2022.` instead of 24 hours. So made some changes.

```
  // A chart with a near start date should be seen as hours from start
  if (!!start && !!end && days < minChartDays) {
    return {measure: 'hour', segments: hoursBetween(moment(end), start)};
  }
```

