### PR TITLE
Add strict-max-fee-flag for rebalance

### DIFF
--- a/bos
+++ b/bos
@@ -1478,6 +1478,7 @@ prog
   .help('--out increases the inbound liquidity with a specific peer/tag')
   .option('--amount <amount>', 'Maximum amount to rebalance')
   .option('--avoid <pubkey_or_chanid>', 'Avoid forwarding through', REPEATABLE)
+  .option('--avoid-high-fee-routes', 'Avoid routes above max-fee')
   .option('--in <pubkey_or_alias>', 'Route in through a specific peer')
   .option('--in-filter <in_filter>', 'Filter inbound tag nodes', REPEATABLE)
   .option('--in-target-outbound <amt>', 'Balance up to outbound amount')
@@ -1489,7 +1490,6 @@ prog
   .option('--out <pubkey_or_alias>', 'Route out through a specific peer')
   .option('--out-filter <out_filter>', 'Filter outbound tag nodes', REPEATABLE)
   .option('--out-target-inbound <amount>', 'Balance up to inbound amount')
-  .option('--strict-max-fee <strict_max_fee>', 'Strict maximum fee to pay')
   .action((args, options, logger) => {
     return new Promise(async (resolve, reject) => {
       try {
@@ -1500,6 +1500,7 @@ prog
           in_filters: flatten([options.inFilter].filter(n => !!n)),
           in_outbound: options.inTargetOutbound || undefined,
           in_through: options.in || undefined,
+          is_strict_max_fee: options.avoidHighFeeRoutes || undefined,
           lnd: (await lndForNode(logger, options.node)).lnd,
           max_fee: options.maxFee,
           max_fee_rate: options.maxFeeRate,
@@ -1507,7 +1508,6 @@ prog
           out_filters: flatten([options.outFilter].filter(n => !!n)),
           out_inbound: options.outTargetInbound,
           out_through: options.out || undefined,
-          strict_max_fee: options.strictMaxFee,
           timeout_minutes: options.minutes || undefined,
         },
         responses.returnObject({exit, logger, reject, resolve}));

--- a/bos
+++ b/bos
@@ -1489,6 +1489,7 @@ prog
   .option('--out <pubkey_or_alias>', 'Route out through a specific peer')
   .option('--out-filter <out_filter>', 'Filter outbound tag nodes', REPEATABLE)
   .option('--out-target-inbound <amount>', 'Balance up to inbound amount')
+  .option('--strict-max-fee <strict_max_fee>', 'Strict maximum fee to pay')
   .action((args, options, logger) => {
     return new Promise(async (resolve, reject) => {
       try {
@@ -1506,6 +1507,7 @@ prog
           out_filters: flatten([options.outFilter].filter(n => !!n)),
           out_inbound: options.outTargetInbound,
           out_through: options.out || undefined,
+          strict_max_fee: options.strictMaxFee,
           timeout_minutes: options.minutes || undefined,
         },
         responses.returnObject({exit, logger, reject, resolve}));

--- a/bos
+++ b/bos
@@ -1478,7 +1478,7 @@ prog
   .help('--out increases the inbound liquidity with a specific peer/tag')
   .option('--amount <amount>', 'Maximum amount to rebalance')
   .option('--avoid <pubkey_or_chanid>', 'Avoid forwarding through', REPEATABLE)
-  .option('--avoid-high-fee-routes', 'Avoid routes above max-fee')
+  .option('--avoid-high-fee-routes', 'Avoid evaluating routes above max-fee')
   .option('--in <pubkey_or_alias>', 'Route in through a specific peer')
   .option('--in-filter <in_filter>', 'Filter inbound tag nodes', REPEATABLE)
   .option('--in-target-outbound <amt>', 'Balance up to outbound amount')

--- a/bos
+++ b/bos
@@ -1478,7 +1478,7 @@ prog
   .help('--out increases the inbound liquidity with a specific peer/tag')
   .option('--amount <amount>', 'Maximum amount to rebalance')
   .option('--avoid <pubkey_or_chanid>', 'Avoid forwarding through', REPEATABLE)
-  .option('--avoid-high-fee-routes', 'Avoid evaluating routes above max-fee')
+  .option('--avoid-high-fee-routes', 'Avoid evaluating routes above max-fee-rate')
   .option('--in <pubkey_or_alias>', 'Route in through a specific peer')
   .option('--in-filter <in_filter>', 'Filter inbound tag nodes', REPEATABLE)
   .option('--in-target-outbound <amt>', 'Balance up to outbound amount')

--- a/network/execute_probe.js
+++ b/network/execute_probe.js
@@ -130,7 +130,7 @@ module.exports = (args, cbk) => {
           ignore: args.ignore,
           incoming_peer: args.in_through,
           lnd: args.lnd,
-          max_fee: !args.is_strict_max_fee ? undefined : args.max_fee,
+          max_fee_mtokens: !args.is_strict_max_fee ? undefined : tokensAsMillitokens(args.max_fee),
           max_timeout_height: args.max_timeout_height,
           messages: args.messages,
           outgoing_channel: args.outgoing_channel,

--- a/network/execute_probe.js
+++ b/network/execute_probe.js
@@ -49,6 +49,7 @@ const tokensAsMillitokens = tok => (BigInt(tok) * BigInt(1e3)).toString();
       icons: [<Icon String>]
       public_key: <Public Key Hex String>
     }]
+    [strict_max_fee]: < Strict Maximum Fee Tokens Number>
     [timeout_minutes]: <Stop Searching For Route After N Minutes Number>
     tokens: <Tokens To Probe Number>
     [total_mtokens]: <Total Millitokens String>
@@ -121,6 +122,7 @@ module.exports = (args, cbk) => {
         const start = now();
 
         const timeoutMinutes = minutesAsMs((args.timeout_minutes || Number()));
+        const maxFee = args.strict_max_fee || (!args.is_strict_max_fee ? undefined : args.max_fee);
 
         const sub = subscribeToProbeForRoute({
           mtokens,
@@ -130,7 +132,7 @@ module.exports = (args, cbk) => {
           ignore: args.ignore,
           incoming_peer: args.in_through,
           lnd: args.lnd,
-          max_fee: !args.is_strict_max_fee ? undefined : args.max_fee,
+          max_fee: maxFee,
           max_timeout_height: args.max_timeout_height,
           messages: args.messages,
           outgoing_channel: args.outgoing_channel,

--- a/network/execute_probe.js
+++ b/network/execute_probe.js
@@ -30,6 +30,7 @@ const tokensAsMillitokens = tok => (BigInt(tok) * BigInt(1e3)).toString();
     lnd: <Authenticated LND API Object>
     logger: <Winston Logger Object>
     [max_fee]: <Maximum Fee Tokens Number>
+    [max_fee_mtokens]: <Maximum Fee Millitokens Number>
     [max_timeout_height]: <Maximum Timeout Height Number>
     [messages]: [{
       type: <Message To Final Destination Type Number String>
@@ -98,6 +99,10 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedLoggerToExecuteProbe']);
         }
 
+        if (!!args.max_fee && !!args.max_fee_mtokens) {
+          return cbk([400, 'ExpectedEitherMaxFeeOrMaxFeeMtokensToExecuteProbe']);
+        }
+
         if (!args.mtokens && !args.tokens) {
           return cbk([400, 'ExpectedTokensToExecuteProbe']);
         }
@@ -121,6 +126,7 @@ module.exports = (args, cbk) => {
         const start = now();
 
         const timeoutMinutes = minutesAsMs((args.timeout_minutes || Number()));
+        const maxFee = !args.is_strict_max_fee ? undefined : (args.max_fee_mtokens || tokensAsMillitokens(args.max_fee));
 
         const sub = subscribeToProbeForRoute({
           mtokens,
@@ -130,7 +136,7 @@ module.exports = (args, cbk) => {
           ignore: args.ignore,
           incoming_peer: args.in_through,
           lnd: args.lnd,
-          max_fee_mtokens: !args.is_strict_max_fee ? undefined : tokensAsMillitokens(args.max_fee),
+          max_fee_mtokens: maxFee,
           max_timeout_height: args.max_timeout_height,
           messages: args.messages,
           outgoing_channel: args.outgoing_channel,

--- a/network/execute_probe.js
+++ b/network/execute_probe.js
@@ -49,7 +49,6 @@ const tokensAsMillitokens = tok => (BigInt(tok) * BigInt(1e3)).toString();
       icons: [<Icon String>]
       public_key: <Public Key Hex String>
     }]
-    [strict_max_fee]: < Strict Maximum Fee Tokens Number>
     [timeout_minutes]: <Stop Searching For Route After N Minutes Number>
     tokens: <Tokens To Probe Number>
     [total_mtokens]: <Total Millitokens String>
@@ -122,7 +121,6 @@ module.exports = (args, cbk) => {
         const start = now();
 
         const timeoutMinutes = minutesAsMs((args.timeout_minutes || Number()));
-        const maxFee = args.strict_max_fee || (!args.is_strict_max_fee ? undefined : args.max_fee);
 
         const sub = subscribeToProbeForRoute({
           mtokens,
@@ -132,7 +130,7 @@ module.exports = (args, cbk) => {
           ignore: args.ignore,
           incoming_peer: args.in_through,
           lnd: args.lnd,
-          max_fee: maxFee,
+          max_fee: !args.is_strict_max_fee ? undefined : args.max_fee,
           max_timeout_height: args.max_timeout_height,
           messages: args.messages,
           outgoing_channel: args.outgoing_channel,

--- a/network/execute_probe.js
+++ b/network/execute_probe.js
@@ -99,10 +99,6 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedLoggerToExecuteProbe']);
         }
 
-        if (!!args.max_fee && !!args.max_fee_mtokens) {
-          return cbk([400, 'ExpectedEitherMaxFeeOrMaxFeeMtokensToExecuteProbe']);
-        }
-
         if (!args.mtokens && !args.tokens) {
           return cbk([400, 'ExpectedTokensToExecuteProbe']);
         }

--- a/network/probe_destination.js
+++ b/network/probe_destination.js
@@ -97,10 +97,6 @@ module.exports = (args, cbk) => {
           return cbk([400, "ExpectedLoggerToProbeDestination"]);
         }
 
-        if (!!args.max_fee && !!args.max_fee_mtokens) {
-          return cbk([400, 'ExpectedEitherMaxFeeOrMaxFeeMtokensToProbeDestination']);
-        }
-
         return cbk();
       },
 

--- a/network/probe_destination.js
+++ b/network/probe_destination.js
@@ -67,7 +67,6 @@ const tokAsMtok = tokens => (BigInt(tokens || 0) * BigInt(1e3)).toString();
     }]
     [out_through]: <Out Through Peer With Public Key Hex String>
     [request]: <Payment Request String>
-    [strict_max_fee]: < Strict Maximum Fee Tokens Number>
     [timeout_minutes]: <Stop Searching For Route After N Minutes Number>
     [tokens]: <Tokens Number>
   }
@@ -371,7 +370,6 @@ module.exports = (args, cbk) => {
           payment: to.payment,
           routes: to.routes,
           tagged: !!getIcons ? getIcons.nodes : undefined,
-          strict_max_fee: args.strict_max_fee,
           timeout_minutes: args.timeout_minutes || undefined,
           total_mtokens: !!to.payment ? to.mtokens : undefined,
         },

--- a/network/probe_destination.js
+++ b/network/probe_destination.js
@@ -60,6 +60,7 @@ const tokAsMtok = tokens => (BigInt(tokens || 0) * BigInt(1e3)).toString();
     lnd: <Authenticated LND gRPC API Object>
     logger: <Winston Logger Object>
     [max_fee]: <Maximum Fee Tokens Number>
+    [max_fee_mtokens]: <Maximum Fee Millitokens Number>
     [message]: <Message String>
     [messages]: [{
       type: <Additional Message To Final Destination Type Number String>
@@ -94,6 +95,10 @@ module.exports = (args, cbk) => {
 
         if (!args.logger) {
           return cbk([400, "ExpectedLoggerToProbeDestination"]);
+        }
+
+        if (!!args.max_fee && !!args.max_fee_mtokens) {
+          return cbk([400, 'ExpectedEitherMaxFeeOrMaxFeeMtokensToProbeDestination']);
         }
 
         return cbk();
@@ -365,6 +370,7 @@ module.exports = (args, cbk) => {
           lnd: args.lnd,
           logger: args.logger,
           max_fee: args.max_fee,
+          max_fee_mtokens: args.max_fee_mtokens,
           mtokens: !BigInt(to.mtokens) ? tokAsMtok(defaultTokens) : to.mtokens,
           outgoing_channel: outgoingChannelId,
           payment: to.payment,

--- a/network/probe_destination.js
+++ b/network/probe_destination.js
@@ -67,6 +67,7 @@ const tokAsMtok = tokens => (BigInt(tokens || 0) * BigInt(1e3)).toString();
     }]
     [out_through]: <Out Through Peer With Public Key Hex String>
     [request]: <Payment Request String>
+    [strict_max_fee]: < Strict Maximum Fee Tokens Number>
     [timeout_minutes]: <Stop Searching For Route After N Minutes Number>
     [tokens]: <Tokens Number>
   }
@@ -370,6 +371,7 @@ module.exports = (args, cbk) => {
           payment: to.payment,
           routes: to.routes,
           tagged: !!getIcons ? getIcons.nodes : undefined,
+          strict_max_fee: args.strict_max_fee,
           timeout_minutes: args.timeout_minutes || undefined,
           total_mtokens: !!to.payment ? to.mtokens : undefined,
         },

--- a/swaps/manage_rebalance.js
+++ b/swaps/manage_rebalance.js
@@ -25,6 +25,7 @@ const {isArray} = Array;
     [out_filters]: [<Outbound Filter Formula String>]
     [out_inbound]: <Outbound Target Inbound Liquidity Tokens Number>
     [out_through]: <Pay Out Through Peer String>
+    [strict_max_fee]: < Strict Maximum Fee Tokens Number>
     [timeout_minutes]: <Deadline To Stop Rebalance Minutes Number>
   }
 
@@ -53,6 +54,10 @@ module.exports = (args, cbk) => {
 
         if (!args.lnd) {
           return cbk([400, 'ExpectedLndToManageRebalance']);
+        }
+
+        if (isArray(args.strict_max_fee)) {
+          return cbk([400, 'ExpectedSingleStrictMaxFeeValue']);
         }
 
         return cbk();
@@ -99,6 +104,7 @@ module.exports = (args, cbk) => {
             out_filters: args.out_filters,
             out_inbound: args.out_inbound,
             out_through: args.out_through,
+            strict_max_fee: Number(args.strict_max_fee) || undefined,
             timeout_minutes: args.timeout_minutes,
           },
           cbk);

--- a/swaps/manage_rebalance.js
+++ b/swaps/manage_rebalance.js
@@ -56,10 +56,6 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedLndToManageRebalance']);
         }
 
-        if (isArray(args.strict_max_fee)) {
-          return cbk([400, 'ExpectedSingleStrictMaxFeeValue']);
-        }
-
         return cbk();
       },
 

--- a/swaps/manage_rebalance.js
+++ b/swaps/manage_rebalance.js
@@ -16,6 +16,7 @@ const {isArray} = Array;
     [in_filters]: [<Inbound Filter Formula String>]
     [in_outbound]: <Inbound Target Outbound Liquidity Tokens Number>
     [in_through]: <Pay In Through Peer String>
+    [is_strict_max_fee]: <Avoid Probing Too-High Fee Routes Bool>
     lnd: <Authenticated LND API Object>
     logger: <Winston Logger Object>
     [max_fee]: <Maximum Fee Tokens Number>
@@ -25,7 +26,6 @@ const {isArray} = Array;
     [out_filters]: [<Outbound Filter Formula String>]
     [out_inbound]: <Outbound Target Inbound Liquidity Tokens Number>
     [out_through]: <Pay Out Through Peer String>
-    [strict_max_fee]: < Strict Maximum Fee Tokens Number>
     [timeout_minutes]: <Deadline To Stop Rebalance Minutes Number>
   }
 
@@ -96,6 +96,7 @@ module.exports = (args, cbk) => {
             in_filters: args.in_filters,
             in_outbound: args.in_outbound,
             in_through: args.in_through,
+            is_strict_max_fee: args.is_strict_max_fee,
             lnd: args.lnd,
             logger: args.logger,
             max_fee: Number(args.max_fee) || undefined,
@@ -104,7 +105,6 @@ module.exports = (args, cbk) => {
             out_filters: args.out_filters,
             out_inbound: args.out_inbound,
             out_through: args.out_through,
-            strict_max_fee: Number(args.strict_max_fee) || undefined,
             timeout_minutes: args.timeout_minutes,
           },
           cbk);

--- a/swaps/rebalance.js
+++ b/swaps/rebalance.js
@@ -598,7 +598,7 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedDifferentPeersForInboundAndOutbound']);
         }
 
-        const maxFee = !!args.max_fee_rate ? round((args.max_fee_rate * max) / 1e6) : round((defaultMaxFeeRate * max) / 1e6);
+        const maxFee = !!args.max_fee_rate ? round((args.max_fee_rate * tokens) / 1e6) : round((defaultMaxFeeRate * tokens) / 1e6);
 
         return probeDestination({
           tokens,

--- a/swaps/rebalance.js
+++ b/swaps/rebalance.js
@@ -60,6 +60,7 @@ const sumOf = arr => arr.reduce((sum, n) => sum + n);
 const tagFilePath = () => homePath({file: 'tags.json'}).path;
 const times = 6;
 const tokAsBigTok = tokens => !tokens ? undefined : (tokens / 1e8).toFixed(8);
+const tokensAsMillitokens = tok => (BigInt(tok) * BigInt(1e3)).toString();
 const topOf = arr => arr.slice(0, Math.ceil(arr.length / 2));
 const uniq = arr => Array.from(new Set(arr));
 
@@ -598,7 +599,8 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedDifferentPeersForInboundAndOutbound']);
         }
 
-        const maxFee = !!args.max_fee_rate ? round((args.max_fee_rate * tokens) / 1e6) : round((defaultMaxFeeRate * tokens) / 1e6);
+        const mtokens = tokensAsMillitokens(tokens);
+        const maxFee = !!args.max_fee_rate ? round((args.max_fee_rate * mtokens) / 1e6) : round((defaultMaxFeeRate * mtokens) / 1e6);
 
         return probeDestination({
           tokens,
@@ -617,7 +619,7 @@ module.exports = (args, cbk) => {
           is_strict_max_fee: args.is_strict_max_fee,
           logger: args.logger,
           lnd: args.lnd,
-          max_fee: maxFee,
+          max_fee_mtokens: maxFee,
           out_through: getOutbound.public_key,
           timeout_minutes: args.timeout_minutes,
         },

--- a/swaps/rebalance.js
+++ b/swaps/rebalance.js
@@ -81,6 +81,7 @@ const uniq = arr => Array.from(new Set(arr));
     [out_filters]: [<Outbound Filter Formula String>]
     [out_inbound]: <Outbound Target Inbound Liquidity Tokens Number>
     [out_through]: <Pay Out Through Peer String>
+    [strict_max_fee]: < Strict Maximum Fee Tokens Number>
     [timeout_minutes]: <Deadline To Stop Rebalance Minutes Number>
   }
 
@@ -614,6 +615,7 @@ module.exports = (args, cbk) => {
           lnd: args.lnd,
           max_fee: defaultMaxFeeTotal,
           out_through: getOutbound.public_key,
+          strict_max_fee: args.strict_max_fee,
           timeout_minutes: args.timeout_minutes,
         },
         cbk);

--- a/swaps/rebalance.js
+++ b/swaps/rebalance.js
@@ -54,6 +54,7 @@ const probeSizeMinimal = 1e2;
 const probeSizeRegular = 2e5
 const pubKeyHexLength = 66;
 const rateDivisor = 1e6;
+const {round} = Math;
 const sample = a => !!a.length ? a[Math.floor(Math.random()*a.length)] : null;
 const sumOf = arr => arr.reduce((sum, n) => sum + n);
 const tagFilePath = () => homePath({file: 'tags.json'}).path;
@@ -597,6 +598,8 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedDifferentPeersForInboundAndOutbound']);
         }
 
+        const maxFee = !!args.max_fee_rate ? round((args.max_fee_rate * max) / 1e6) : round((defaultMaxFeeRate * max) / 1e6);
+
         return probeDestination({
           tokens,
           destination: getPublicKey.public_key,
@@ -614,7 +617,7 @@ module.exports = (args, cbk) => {
           is_strict_max_fee: args.is_strict_max_fee,
           logger: args.logger,
           lnd: args.lnd,
-          max_fee: args.max_fee || defaultMaxFee,
+          max_fee: maxFee,
           out_through: getOutbound.public_key,
           timeout_minutes: args.timeout_minutes,
         },

--- a/swaps/rebalance.js
+++ b/swaps/rebalance.js
@@ -72,6 +72,7 @@ const uniq = arr => Array.from(new Set(arr));
     [in_filters]: [<Inbound Filter Formula String>]
     [in_outbound]: <Inbound Target Outbound Liquidity Tokens Number>
     [in_through]: <Pay In Through Peer String>
+    [is_strict_max_fee]: <Avoid Probing Too-High Fee Routes Bool>
     lnd: <Authenticated LND API Object>
     logger: <Winston Logger Object>
     [max_fee]: <Maximum Fee Tokens Number>
@@ -81,7 +82,6 @@ const uniq = arr => Array.from(new Set(arr));
     [out_filters]: [<Outbound Filter Formula String>]
     [out_inbound]: <Outbound Target Inbound Liquidity Tokens Number>
     [out_through]: <Pay Out Through Peer String>
-    [strict_max_fee]: < Strict Maximum Fee Tokens Number>
     [timeout_minutes]: <Deadline To Stop Rebalance Minutes Number>
   }
 
@@ -611,11 +611,11 @@ module.exports = (args, cbk) => {
             return ![findInKey, findOutKey].includes(n.from_public_key);
           }),
           in_through: getInbound.public_key,
+          is_strict_max_fee: args.is_strict_max_fee,
           logger: args.logger,
           lnd: args.lnd,
-          max_fee: defaultMaxFeeTotal,
+          max_fee: args.max_fee || defaultMaxFee,
           out_through: getOutbound.public_key,
-          strict_max_fee: args.strict_max_fee,
           timeout_minutes: args.timeout_minutes,
         },
         cbk);


### PR DESCRIPTION
Added strict-max-fee flag for rebalance.

I think this can also be done differently, `probe_destination.js` file already takes a `is_strict_max_fee` argument so I think we can also just add boolean flag called `--strict` which makes the regular `--max-fee` as the strict fee.