### PR TITLE
[call]: Add support for calling lnsync methods

### DIFF
--- a/commands/api.json
+++ b/commands/api.json
@@ -3,6 +3,52 @@
     {
       "arguments": [
         {
+          "description": "Channel capacity tokens",
+          "named": "capacity",
+          "type": "number"
+        },
+        {
+          "description": "Request close out to address for cooperative close",
+          "named": "cooperative_close_address",
+          "optional": true
+        },
+        {
+          "description": "Gift tokens to peer on open",
+          "named": "give_tokens",
+          "optional": true,
+          "type": "boolean"
+        },
+        {
+          "description": "Is private channel?",
+          "named": "is_private",
+          "optional": true,
+          "type": "boolean"
+        },
+        {
+          "description": "Minimum htlc millitokens",
+          "named": "min_htlc_mtokens",
+          "optional": true,
+          "type": "number"
+        },
+        {
+          "description": "Partner output csv delay",
+          "named": "partner_csv_delay",
+          "optional": true,
+          "type": "number"
+        },
+        {
+          "description": "Partner hex encoded public key",
+          "named": "partner_public_key",
+          "type": "public_key"
+        }
+      ],
+      "from": "ln-sync",
+      "method": "acceptsChannelOpen"
+
+    },
+    {
+      "arguments": [
+        {
           "description": "Node identity hex encoded public key",
           "named": "public_key",
           "type": "public_key"
@@ -85,6 +131,17 @@
         }
       ],
       "method": "closeChannel"
+    },
+    {
+      "arguments": [
+        {
+          "description": "Node public key to connect with",
+          "named": "id",
+          "type": "public_key"
+        }
+      ],
+      "from": "ln-sync",
+      "method": "connectPeer"
     },
     {
       "arguments": [
@@ -449,6 +506,10 @@
     },
     {
       "method": "getMethods"
+    },
+    {
+      "from": "ln-sync",
+      "method": "getNetwork"
     },
     {
       "method": "getNetworkCentrality"

--- a/commands/call_raw_api.js
+++ b/commands/call_raw_api.js
@@ -3,11 +3,13 @@ const {parse} = require('querystring');
 const asyncAuto = require('async/auto');
 const asyncMapSeries = require('async/mapSeries');
 const lnService = require('ln-service');
+const lnsync = require('ln-sync');
 const {returnResult} = require('asyncjs-util');
 
 const {calls} = require('./api');
 
 const {assign} = Object;
+const fromLnSync = 'ln-sync';
 const isChannel = n => !!n && /^\d*x\d*x\d*$/.test(n);
 const isHash = n => !!n && /^[0-9A-F]{64}$/i.test(n);
 const isPublicKey = n => !!n && /^0[2-3][0-9A-F]{64}$/i.test(n);
@@ -204,6 +206,10 @@ module.exports = ({ask, lnd, logger, method, params}, cbk) => {
         // Exit early when this is an event-based API
         if (!!methodDetails(calls, getMethod.method).events) {
           return cbk();
+        }
+
+        if (methodDetails(calls, getMethod.method).from === fromLnSync) {
+          return lnsync[getMethod.method](arguments, cbk);
         }
 
         return lnService[getMethod.method](arguments, cbk);


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <niteshbalusu@icloud.com>

Call command can call ln-sync methods:
acceptsChannelOpen
connectPeer
getNetwork
