### PR TITLE
[limit-forwarding]: Add support for disallow pairs

### DIFF
--- a/bos
+++ b/bos
@@ -918,6 +918,7 @@ prog
   .option('--max-new-pending-per-hour <h>', 'Limit held HTLCs', INT)
   .option('--min-channel-confirmations <confs>', 'Minimum channel confs', INT)
   .option('--only-allow <pair>', 'only forward fromKey/toKey', REPEATABLE)
+  .option('--only-disallow <pair>', 'only disable forwards fromKey/toKey', REPEATABLE)
   .action((args, options, logger) => {
     return new Promise(async (resolve, reject) => {
       try {
@@ -929,6 +930,7 @@ prog
           max_new_pending_per_hour: options.maxNewPendingPerHour,
           min_channel_confirmations: options.minChannelConfirmations,
           only_allow: flatten([options.onlyAllow].filter(n => !!n)),
+          only_disallow: flatten([options.onlyDisallow].filter(n => !!n))
         });
       } catch (err) {
         return logger.error({err}) && reject();


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <niteshbalusu@icloud.com>

Added support for disallow pairs in limit-forwarding.