### PR TITLE
Fix for bos send with scid alias

### DIFF
--- a/network/probe_destination.js
+++ b/network/probe_destination.js
@@ -257,7 +257,6 @@ module.exports = (args, cbk) => {
             .filter(n => n.bit !== featureTypeTrustedFunding)
             .filter(n => !!n.type)
 
-
           return cbk(null, {features});
         }
 

--- a/network/probe_destination.js
+++ b/network/probe_destination.js
@@ -252,14 +252,6 @@ module.exports = (args, cbk) => {
         // If the destination is a peer, use the peer features
         if (!!getPeerFeatures.features.length) {
           const features = getPeerFeatures.features
-            .map(n => {
-              return {
-                bit: Number(n.bit),
-                is_known: n.is_known,
-                is_required: n.is_required,
-                type: n.type,
-              }
-            })
             .filter(n => !!n.is_known)
             .filter(n => n.bit !== featureTypeChannelType)
             .filter(n => n.bit !== featureTypeTrustedFunding)
@@ -395,7 +387,7 @@ module.exports = (args, cbk) => {
         'outgoingChannelId',
         'to',
         ({getFeatures, getIcons, messages, outgoingChannelId, to}, cbk) =>
-      {        
+      {
         return executeProbe({
           messages,
           cltv_delta: (to.cltv_delta || defaultCltvDelta) + cltvBuffer,

--- a/network/probe_destination.js
+++ b/network/probe_destination.js
@@ -2,10 +2,11 @@ const {createHash} = require('crypto');
 const {randomBytes} = require('crypto');
 
 const asyncAuto = require('async/auto');
-const {decodePaymentRequest, getPeers} = require('ln-service');
+const {decodePaymentRequest} = require('ln-service');
 const {getChannels} = require('ln-service');
 const {getIdentity} = require('ln-service');
 const {getNode} = require('ln-service');
+const {getPeers} = require('ln-service');
 const moment = require('moment');
 const {parsePaymentRequest} = require('ln-service');
 const {payViaRoutes} = require('ln-service');

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "ini": "4.0.0",
         "inquirer": "9.1.5",
         "ln-accounting": "6.1.3",
-        "ln-service": "54.10.6",
+        "ln-service": "54.10.7",
         "ln-sync": "4.3.2",
         "ln-telegram": "4.6.1",
         "moment": "2.29.4",
@@ -6130,15 +6130,15 @@
       }
     },
     "node_modules/ln-service": {
-      "version": "54.10.6",
-      "resolved": "https://registry.npmjs.org/ln-service/-/ln-service-54.10.6.tgz",
-      "integrity": "sha512-e68U7pitpF9BGNjRcTPXeCOyjPD+9OSjs70/4mjZcq4lNtvF5eehq7TMdOCZWJUp8ogvgvP1SIWQygwirkHSIQ==",
+      "version": "54.10.7",
+      "resolved": "https://registry.npmjs.org/ln-service/-/ln-service-54.10.7.tgz",
+      "integrity": "sha512-YRPqvyaEJPsR+ljizoSwYueHPVWmND32PLsL9JSb3CnLmVUvXcqQh0zl4Q7TVR31qeW7Vh/Q0ldbXu0vtSMsWA==",
       "dependencies": {
         "bolt07": "1.8.3",
         "cors": "2.8.5",
         "express": "4.18.2",
         "invoices": "2.2.3",
-        "lightning": "7.1.6",
+        "lightning": "7.1.9",
         "macaroon": "3.0.4",
         "morgan": "1.10.0",
         "ws": "8.13.0"
@@ -6148,9 +6148,9 @@
       }
     },
     "node_modules/ln-service/node_modules/lightning": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/lightning/-/lightning-7.1.6.tgz",
-      "integrity": "sha512-+nPyNjoaig8FDdcdmCGbHCFZ6Anb+kX1cniJwPyzPgtHroPlbl2gtfSmWvrWTOuo74HuQEbQ4dpOoj7OIjM6jg==",
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/lightning/-/lightning-7.1.9.tgz",
+      "integrity": "sha512-p5VreRPpRAPQ66LFANuvhWCutipuly07qterFjbzxJGwkgfaWw6L+K25UipfB0kYJvsZNTEfzCszQBO07Y1Ujw==",
       "dependencies": {
         "@grpc/grpc-js": "1.8.13",
         "@grpc/proto-loader": "0.7.6",
@@ -6171,16 +6171,16 @@
         "invoices": "2.2.3",
         "psbt": "2.7.2",
         "tiny-secp256k1": "2.2.1",
-        "type-fest": "3.7.2"
+        "type-fest": "3.8.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/ln-service/node_modules/type-fest": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.7.2.tgz",
-      "integrity": "sha512-f9BHrLjRJ4MYkfOsnC/53PNDzZJcVo14MqLp2+hXE39p5bgwqohxR5hDZztwxlbxmIVuvC2EFAKrAkokq23PLA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.8.0.tgz",
+      "integrity": "sha512-FVNSzGQz9Th+/9R6Lvv7WIAkstylfHN2/JYxkyhhmKFYh9At2DST8t6L6Lref9eYO8PXFTfG9Sg1Agg0K3vq3Q==",
       "engines": {
         "node": ">=14.16"
       },
@@ -14273,24 +14273,24 @@
       }
     },
     "ln-service": {
-      "version": "54.10.6",
-      "resolved": "https://registry.npmjs.org/ln-service/-/ln-service-54.10.6.tgz",
-      "integrity": "sha512-e68U7pitpF9BGNjRcTPXeCOyjPD+9OSjs70/4mjZcq4lNtvF5eehq7TMdOCZWJUp8ogvgvP1SIWQygwirkHSIQ==",
+      "version": "54.10.7",
+      "resolved": "https://registry.npmjs.org/ln-service/-/ln-service-54.10.7.tgz",
+      "integrity": "sha512-YRPqvyaEJPsR+ljizoSwYueHPVWmND32PLsL9JSb3CnLmVUvXcqQh0zl4Q7TVR31qeW7Vh/Q0ldbXu0vtSMsWA==",
       "requires": {
         "bolt07": "1.8.3",
         "cors": "2.8.5",
         "express": "4.18.2",
         "invoices": "2.2.3",
-        "lightning": "7.1.6",
+        "lightning": "7.1.9",
         "macaroon": "3.0.4",
         "morgan": "1.10.0",
         "ws": "8.13.0"
       },
       "dependencies": {
         "lightning": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/lightning/-/lightning-7.1.6.tgz",
-          "integrity": "sha512-+nPyNjoaig8FDdcdmCGbHCFZ6Anb+kX1cniJwPyzPgtHroPlbl2gtfSmWvrWTOuo74HuQEbQ4dpOoj7OIjM6jg==",
+          "version": "7.1.9",
+          "resolved": "https://registry.npmjs.org/lightning/-/lightning-7.1.9.tgz",
+          "integrity": "sha512-p5VreRPpRAPQ66LFANuvhWCutipuly07qterFjbzxJGwkgfaWw6L+K25UipfB0kYJvsZNTEfzCszQBO07Y1Ujw==",
           "requires": {
             "@grpc/grpc-js": "1.8.13",
             "@grpc/proto-loader": "0.7.6",
@@ -14311,13 +14311,13 @@
             "invoices": "2.2.3",
             "psbt": "2.7.2",
             "tiny-secp256k1": "2.2.1",
-            "type-fest": "3.7.2"
+            "type-fest": "3.8.0"
           }
         },
         "type-fest": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.7.2.tgz",
-          "integrity": "sha512-f9BHrLjRJ4MYkfOsnC/53PNDzZJcVo14MqLp2+hXE39p5bgwqohxR5hDZztwxlbxmIVuvC2EFAKrAkokq23PLA=="
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.8.0.tgz",
+          "integrity": "sha512-FVNSzGQz9Th+/9R6Lvv7WIAkstylfHN2/JYxkyhhmKFYh9At2DST8t6L6Lref9eYO8PXFTfG9Sg1Agg0K3vq3Q=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ini": "4.0.0",
     "inquirer": "9.1.5",
     "ln-accounting": "6.1.3",
-    "ln-service": "54.10.6",
+    "ln-service": "54.10.7",
     "ln-sync": "4.3.2",
     "ln-telegram": "4.6.1",
     "moment": "2.29.4",


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <niteshbalusu@icloud.com>

Get peers is returning strings for feature bit numbers, i added a type conversion for now. If getPeers is fixed this part can be removed.

```
            .map(n => {
              return {
                bit: Number(n.bit),
                is_known: n.is_known,
                is_required: n.is_required,
                type: n.type,
              }
            })
```