### PR TITLE
[chain-deposit]: Default chain deposit address to taproot

### DIFF
--- a/bos
+++ b/bos
@@ -272,7 +272,7 @@ prog
   .command('chain-deposit', 'Deposit coins in the on-chain wallet')
   .help('--format address types supported: np2wpkh, p2tr, p2wpkh (default)')
   .argument('[amount]', 'Amount to receive', INT)
-  .option('--format <format>', 'Address type', ['np2wpkh', 'p2tr', 'p2wpkh'])
+  .option('--format <format>', 'Address type', ['np2wpkh', 'p2tr', 'p2wpkh'], 'p2tr')
   .option('--fresh', 'Create a fresh address')
   .option('--no-color', 'Mute all colors')
   .option('--node <node_name>', 'Node to deposit coins to')


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <84944042+niteshbalusu11@users.noreply.github.com>

Lnd has been supporting taproot addresses for a while now, I think its nice to default to taproot for chain-deposit.