### PR TITLE
[open]: Add simple balance check for bos open

### DIFF
--- a/peers/open_channels.js
+++ b/peers/open_channels.js
@@ -471,7 +471,7 @@ module.exports = (args, cbk) => {
         ({internal}) => cbk(null, !internal));
       }],
 
-      // Check balance
+      // Make sure there is enough coins to fund the open
       checkBalance: ['isExternal', 'opens', ({isExternal, opens}, cbk) => {
         // Exit early when externally funding
         if (!!isExternal) {

--- a/peers/open_channels.js
+++ b/peers/open_channels.js
@@ -480,7 +480,7 @@ module.exports = (args, cbk) => {
 
         const [{channels}] = opens;
 
-        getChainBalance({lnd: args.lnd}, (err, res) => {
+        return getChainBalance({lnd: args.lnd}, (err, res) => {
           if (!!err) {
             return cbk(err);
           }

--- a/peers/open_channels.js
+++ b/peers/open_channels.js
@@ -496,7 +496,7 @@ module.exports = (args, cbk) => {
       }],
 
       // Ask for the fee rate to use for internally funded opens
-      askForFeeRate: ['isExternal', 'checkBalance', ({isExternal}, cbk) => {
+      askForFeeRate: ['checkBalance', 'isExternal', ({isExternal}, cbk) => {
         // Exit early when there are no internal funds being spent or internal fee rate is specified
         if (!!isExternal || !!args.internal_fund_fee_rate) {
           return cbk(null, {});

--- a/peers/open_channels.js
+++ b/peers/open_channels.js
@@ -473,27 +473,27 @@ module.exports = (args, cbk) => {
 
       // Check balance
       checkBalance: ['isExternal', 'opens', ({isExternal, opens}, cbk) => {
-          // Exit early when externally funding
-          if (!!isExternal) {
-            return cbk();
-          }
-          const [{channels}] = opens;
-
-          getChainBalance({lnd: args.lnd}, (err, res) => {
-            if (!!err) {
-              return cbk(err);
-            }
-
-            const totalCapacity = channels.reduce((acc, n) => acc + n.capacity, 0);
-
-            if (res.chain_balance < totalCapacity) {
-              return cbk([400, 'ExpectedChainBalanceToMatchTotalCapacityBeingOpened']);
-            }
-
-            return cbk();
-          });
+        // Exit early when externally funding
+        if (!!isExternal) {
+          return cbk();
         }
-      ],
+
+        const [{channels}] = opens;
+
+        getChainBalance({lnd: args.lnd}, (err, res) => {
+          if (!!err) {
+            return cbk(err);
+          }
+
+          const totalCapacity = channels.reduce((acc, n) => acc + n.capacity, 0);
+
+          if (res.chain_balance < totalCapacity) {
+            return cbk([400, 'ExpectedChainBalanceToMatchTotalCapacityBeingOpened']);
+          }
+
+          return cbk();
+        });
+      }],
 
       // Ask for the fee rate to use for internally funded opens
       askForFeeRate: ['isExternal', 'checkBalance', ({isExternal}, cbk) => {


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <84944042+niteshbalusu11@users.noreply.github.com>

I have noticed this morning that when doing an internal channel open, if you don't have enough chain balance and the open fails, it's leaving behind pending channels and if you clear the terminal its hard to get the IDs to cancel those pending channels.
Added a simple chain balance check so that channel open isn't attempted if you don't have enough balance.