### PR TITLE
Display rounded sats in case of --use-small-units option

### DIFF
--- a/telegram/connect_to_telegram.js
+++ b/telegram/connect_to_telegram.js
@@ -12,7 +12,7 @@ const runTelegramBot = require('./run_telegram_bot');
 const defaultPaymentsBudget = 0;
 const isNumber = n => !isNaN(n);
 const restartDelayMs = 1000 * 60 * 3;
-const smallUnitsType = 'full';
+const smallUnitsType = 'rounded';
 
 /** Connect nodes to Telegram
 


### PR DESCRIPTION
Relies on PR for ln-telegram module to add 'rounded' token format. as communicated via process.env.PREFERRED_TOKENS_TYPE = 'rounded'