### PR TITLE
Changes-to-lsps1

### DIFF
--- a/bos
+++ b/bos
@@ -1301,7 +1301,6 @@ prog
   .option('--min-capacity <tokens>', 'Minimum channel capacity', INT, 1e6)
   .option('--node <node_name>', 'Node to offer channels on')
   .option('--private-fee-rate <ppm>', 'Add private capacity charge', INT, 1000)
-  .option('--website <url>', 'URL to advertise as informational website')
   .action((args, options, logger) => {
     return new Promise(async (resolve, reject) => {
       try {
@@ -1314,7 +1313,6 @@ prog
           min_capacity: options.minCapacity,
           orders: new Map(),
           private_fee_rate: options.privateFeeRate,
-          website: options.website,
         },
         responses.returnObject({logger, reject, resolve}));
       } catch (err) {

--- a/lsp/constants.json
+++ b/lsp/constants.json
@@ -1,6 +1,7 @@
 {
   "assumedOpenTransactionVbytes": 150,
   "defaultChannelActiveConfs": 6,
+  "defaultFundingConfirmedBlocks": 3,
   "defaultLifetimeBlocks": 13000,
   "defaultLifetimeDays": 90
 }

--- a/lsp/lsps1_client.js
+++ b/lsp/lsps1_client.js
@@ -244,7 +244,7 @@ module.exports = (args, cbk) => {
             announce_channel: isAnnounced(args.type),
             channel_expiry_blocks: lifetime,
             client_balance_sat: Number().toString(),
-            confirms_within_blocks: hoursAsBlocks(args.max_wait_hours),
+            funding_confirms_within_blocks: hoursAsBlocks(args.max_wait_hours),
             lsp_balance_sat: args.capacity.toString(),
             token: String(),
           },

--- a/lsp/lsps1_server.js
+++ b/lsp/lsps1_server.js
@@ -35,7 +35,6 @@ const {now} = Date;
     min_capacity: <Minimum Capacity Tokens Number>
     orders: <Orders Map Object>
     private_fee_rate: <Proportional Added Fee PPM for Private Channels Number>
-    [website]: <Website String>
   }
 
   @returns via cbk or Promise
@@ -75,15 +74,6 @@ module.exports = (args, cbk) => {
 
         if (args.private_fee_rate === undefined) {
           return cbk([400, 'ExpectedPrivateFeeRateToRunLsp1Server']);
-        }
-
-        // Make sure the website is a valid URL
-        if (!!args.website) {
-          try {
-            new URL(args.website);
-          } catch (err) {
-            return cbk([400, 'ExpectedValidUrlToRunLsp1Server']);
-          }
         }
 
         return cbk();
@@ -179,7 +169,6 @@ module.exports = (args, cbk) => {
                 min_capacity: args.min_capacity,
                 lnd: args.lnd,
                 to_peer: received.public_key,
-                website: args.website,
               });
             } catch (err) {
               return args.logger.error({err});

--- a/lsp/process_order.js
+++ b/lsp/process_order.js
@@ -164,13 +164,13 @@ module.exports = (args, cbk) => {
           });
         }
 
-        if (!isNumber(message.params.confirms_within_blocks)) {
+        if (!isNumber(message.params.funding_confirms_within_blocks)) {
           return cbk(null, {
             error: makeErrorMessage({
               code: codeInvalidParameters,
               data: {
                 message: 'MissingConfirmsWithinBlocksInCreateOrderRequest',
-                property: 'confirms_within_blocks',
+                property: 'funding_confirms_within_blocks',
               },
               id: message.id,
               message: errMessageInvalidParams,
@@ -305,7 +305,7 @@ module.exports = (args, cbk) => {
           return cbk();
         }
 
-        const blocks = getMessage.params.confirms_within_blocks;
+        const blocks = getMessage.params.funding_confirms_within_blocks;
 
         return getChainFeeRate({
           confirmation_target: Number(blocks),
@@ -443,7 +443,7 @@ module.exports = (args, cbk) => {
             channel: null,
             channel_expiry_blocks: defaultLifetimeBlocks,
             client_balance_sat: Number().toString(),
-            confirms_within_blocks: message.params.confirms_within_blocks,
+            funding_confirms_within_blocks: message.params.funding_confirms_within_blocks,
             created_at: new Date().toISOString(),
             expires_at: expiryDate(orderExpiryMs),
             lsp_balance_sat: message.params.lsp_balance_sat,
@@ -483,7 +483,7 @@ module.exports = (args, cbk) => {
           return cbk();
         }
 
-        const blocks = getMessage.params.confirms_within_blocks;
+        const blocks = getMessage.params.funding_confirms_within_blocks;
 
         return getChainFeeRate({
           confirmation_target: Number(blocks),

--- a/lsp/send_info.js
+++ b/lsp/send_info.js
@@ -5,6 +5,7 @@ const {sendMessageToPeer} = require('ln-service');
 const {codeInvalidParameters} = require('./lsps1_protocol');
 const {defaultChannelActiveConfs} = require('./constants');
 const {defaultLifetimeBlocks} = require('./constants');
+const {defaultFundingConfirmedBlocks} = require('./constants')
 const {errMessageInvalidParams} = require('./lsps1_protocol');
 const {typeForMessaging} = require('./lsps1_protocol');
 const {versionJsonRpc} = require('./lsps1_protocol');
@@ -91,11 +92,12 @@ module.exports = (args, cbk) => {
               max_initial_client_balance_sat: Number().toString(),
               max_initial_lsp_balance_sat: args.max_capacity.toString(),
               min_channel_balance_sat: args.min_capacity.toString(),
-              min_channel_confirmations: defaultChannelActiveConfs,
+              min_funding_confirms_within_blocks: defaultFundingConfirmedBlocks,
               min_initial_client_balance_sat: Number().toString(),
               min_initial_lsp_balance_sat: args.min_capacity.toString(),
               min_onchain_payment_confirmations: null,
               min_onchain_payment_size_sat: null,
+              min_required_channel_confirmations: defaultChannelActiveConfs,
               supports_zero_channel_reserve: false,
             },
           },

--- a/lsp/send_info.js
+++ b/lsp/send_info.js
@@ -20,7 +20,6 @@ const encodeMessage = obj => Buffer.from(JSON.stringify(obj)).toString('hex');
     min_capacity: <Minimum Supported Channel Capacity Tokens Number>
     lnd: <Authenticated LND API Object>
     to_peer: <Peer Public Key Hex String>
-    [website]: <Related Website URL String>
   }
 
   @returns via cbk or Promise
@@ -99,7 +98,6 @@ module.exports = (args, cbk) => {
               min_onchain_payment_size_sat: null,
               supports_zero_channel_reserve: false,
             },
-            website: args.website || String(),
           },
         });
       }],


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <niteshbalusu@icloud.com>

Website is no longer supported. removed it.

`confirms_within_blocks` is now called `funding_confirms_within_blocks`

While sending info its now called `min_funding_confirms_within_blocks`

`min_channel_confirmations` is now `min_required_channel_confirmations`


New `min_funding_confirms_within_blocks` has been added.