### PR TITLE
LSPS1: processOrder: fix return of channel_expiry_blocks

### DIFF
--- a/lsp/process_order.js
+++ b/lsp/process_order.js
@@ -443,7 +443,7 @@ module.exports = (args, cbk) => {
           result: {
             announce_channel: !!message.params.announce_channel,
             channel: null,
-            channel_expiry_blocks: defaultLifetimeBlocks,
+            channel_expiry_blocks: message.params.channel_expiry_blocks,
             client_balance_sat: Number().toString(),
             funding_confirms_within_blocks: confTarget,
             created_at: new Date().toISOString(),


### PR DESCRIPTION
Since we use this value to calculate the fee on lines 331 and 340 (https://github.com/alexbosworth/balanceofsatoshis/compare/master...kaloudis:channel_expiry_blocks-fix?expand=1#diff-c65d0bbd023857dc452499d3659b3730115dc0024dbe3c7d038c8f323ae77f54R331), we should record and return it properly in the order object, otherwise users may have a workaround to attain a discount

